### PR TITLE
Enable or disable cascading on each uploader

### DIFF
--- a/lib/carrierwave-cascade.rb
+++ b/lib/carrierwave-cascade.rb
@@ -15,8 +15,10 @@ class CarrierWave::Uploader::Base
   add_config :primary_storage
   add_config :secondary_storage
   add_config :allow_secondary_file_deletion
+  add_config :enable_cascade
 
   configure do |config|
     config.storage_engines[:cascade] = 'CarrierWave::Storage::Cascade'
+    config.enable_cascade = true
   end
 end

--- a/spec/carrierwave-cascade_spec.rb
+++ b/spec/carrierwave-cascade_spec.rb
@@ -4,6 +4,7 @@ describe CarrierWave::Uploader::Base do
   it { is_expected.to respond_to :primary_storage }
   it { is_expected.to respond_to :secondary_storage }
   it { is_expected.to respond_to :allow_secondary_file_deletion }
+  it { is_expected.to respond_to :enable_cascade }
 
   describe '#storage_engines' do
     subject { super().storage_engines }


### PR DESCRIPTION
Using two Fog storages increases the system's overhead, as
it adds an extra remote request to every #retrieve! call.

In our particular use case, only a minority of uploader instances
will need to use the cascade mechanism, so we want to disable
it for those who don't.
